### PR TITLE
feat: Add direct Line Protocol support and decouple converter architecture

### DIFF
--- a/src/main/java/org/opengemini/flink/sink/OpenGeminiLineProtocolConverter.java
+++ b/src/main/java/org/opengemini/flink/sink/OpenGeminiLineProtocolConverter.java
@@ -17,21 +17,19 @@ package org.opengemini.flink.sink;
 
 import java.io.Serializable;
 
-import io.opengemini.client.api.Point;
-
 /**
- * Enhanced converter interface for converting objects to OpenGemini Points. This provides better
- * integration with the OpenGemini client.
+ * Enhanced converter interface for converting objects to OpenGemini line protocol. This provides
+ * better integration with the OpenGemini client.
  *
  * @param <T> The type of object to convert
  */
-public interface OpenGeminiPointConverter<T> extends Serializable {
+public interface OpenGeminiLineProtocolConverter<T> extends Serializable {
     /**
-     * Convert an object to an OpenGemini Point.
+     * Convert an object to a line protocol string for OpenGemini.
      *
      * @param value The value to convert
      * @param measurement The measurement name
-     * @return The converted Point, or null if the value should be skipped
+     * @return The converted line protocol string, or null if the value should be skipped
      */
-    Point convertToPoint(T value, String measurement) throws Exception;
+    String convertToLineProtocol(T value, String measurement) throws Exception;
 }

--- a/src/main/java/org/opengemini/flink/table/AbstractRowDataConverter.java
+++ b/src/main/java/org/opengemini/flink/table/AbstractRowDataConverter.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2025 openGemini authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengemini.flink.table;
+
+import java.io.Serializable;
+import java.util.*;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import io.opengemini.client.api.Precision;
+
+public abstract class AbstractRowDataConverter implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    protected final OpenGeminiDynamicTableSinkFactory.FieldMappingConfig fieldMapping;
+    protected final String measurement;
+    protected final List<String> columnNames;
+    protected final List<LogicalType> columnTypes;
+    protected final Set<String> tagColumns;
+    protected final Set<String> fieldColumns;
+    protected final int timestampFieldIndex;
+    protected final Map<String, Integer> columnIndexMap;
+
+    public static final String PRECISION_NANOSECOND = "ns";
+    public static final String PRECISION_MICROSECOND = "us";
+    public static final String PRECISION_MILLISECOND = "ms";
+    public static final String PRECISION_SECOND = "s";
+    public static final String PRECISION_MINUTE = "m";
+    public static final String PRECISION_HOUR = "h";
+
+    public AbstractRowDataConverter(
+            ResolvedSchema schema,
+            OpenGeminiDynamicTableSinkFactory.FieldMappingConfig fieldMapping,
+            String measurement) {
+        this.fieldMapping = fieldMapping;
+        this.measurement = measurement;
+
+        // Extract column information
+        this.columnNames = schema.getColumnNames();
+        this.columnTypes =
+                schema.getColumnDataTypes().stream()
+                        .map(DataType::getLogicalType)
+                        .collect(java.util.stream.Collectors.toList());
+
+        // Build column index map for quick lookup
+        this.columnIndexMap = new HashMap<>();
+        for (int i = 0; i < columnNames.size(); i++) {
+            columnIndexMap.put(columnNames.get(i), i);
+        }
+
+        // Determine tag and field columns
+        this.tagColumns = new HashSet<>(fieldMapping.getTagFields());
+        this.fieldColumns = new HashSet<>();
+
+        if (!fieldMapping.getFieldFields().isEmpty()) {
+            this.fieldColumns.addAll(fieldMapping.getFieldFields());
+        } else {
+            // If not specified, all non-tag columns are field columns
+            for (String col : columnNames) {
+                if (!tagColumns.contains(col) && !col.equals(fieldMapping.getTimestampField())) {
+                    fieldColumns.add(col);
+                }
+            }
+        }
+
+        // Find timestamp field index
+        String timestampField = fieldMapping.getTimestampField();
+        if (timestampField != null && columnIndexMap.containsKey(timestampField)) {
+            this.timestampFieldIndex = columnIndexMap.get(timestampField);
+        } else {
+            this.timestampFieldIndex = -1; // Will use current time
+        }
+    }
+
+    public Precision getPrecision() {
+        switch (fieldMapping.getSourceTimestampPrecision()) {
+            case PRECISION_NANOSECOND:
+                return Precision.PRECISIONNANOSECOND;
+            case PRECISION_MICROSECOND:
+                return Precision.PRECISIONMICROSECOND;
+            case PRECISION_MILLISECOND:
+                return Precision.PRECISIONMILLISECOND;
+            case PRECISION_SECOND:
+                return Precision.PRECISIONSECOND;
+            case PRECISION_MINUTE:
+                return Precision.PRECISIONMINUTE;
+            case PRECISION_HOUR:
+                return Precision.PRECISIONHOUR;
+            default:
+                return Precision.PRECISIONMILLISECOND;
+        }
+    }
+
+    public long extractTimestamp(RowData rowData) {
+        if (timestampFieldIndex >= 0 && !rowData.isNullAt(timestampFieldIndex)) {
+            LogicalType type = columnTypes.get(timestampFieldIndex);
+            switch (type.getTypeRoot()) {
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                    // Flink timestamps are in milliseconds
+                    return rowData.getTimestamp(timestampFieldIndex, 3).getMillisecond();
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    return rowData.getTimestamp(timestampFieldIndex, 3).getMillisecond();
+                case BIGINT:
+                    // Assume bigint timestamps are in the configured precision
+                    long ts = rowData.getLong(timestampFieldIndex);
+                    return convertToNanos(ts);
+                default:
+                    // Fallback to current time
+                    return System.currentTimeMillis();
+            }
+        }
+        // Use current time if no timestamp field
+        return System.currentTimeMillis();
+    }
+
+    public String extractStringValue(RowData rowData, int index, LogicalType type) {
+        if (rowData.isNullAt(index)) {
+            return null;
+        }
+
+        switch (type.getTypeRoot()) {
+            case VARCHAR:
+            case CHAR:
+                return rowData.getString(index).toString();
+            case BOOLEAN:
+                return String.valueOf(rowData.getBoolean(index));
+            case TINYINT:
+                return String.valueOf(rowData.getByte(index));
+            case SMALLINT:
+                return String.valueOf(rowData.getShort(index));
+            case INTEGER:
+                return String.valueOf(rowData.getInt(index));
+            case BIGINT:
+                return String.valueOf(rowData.getLong(index));
+            case FLOAT:
+                return String.valueOf(rowData.getFloat(index));
+            case DOUBLE:
+                return String.valueOf(rowData.getDouble(index));
+            default:
+                return rowData.getString(index).toString();
+        }
+    }
+
+    public Object extractFieldValue(RowData rowData, int index, LogicalType type) {
+        if (rowData.isNullAt(index)) {
+            return null;
+        }
+
+        switch (type.getTypeRoot()) {
+            case BOOLEAN:
+                return rowData.getBoolean(index);
+            case TINYINT:
+                return (int) rowData.getByte(index);
+            case SMALLINT:
+                return (int) rowData.getShort(index);
+            case INTEGER:
+                return rowData.getInt(index);
+            case BIGINT:
+                return rowData.getLong(index);
+            case FLOAT:
+                return rowData.getFloat(index);
+            case DOUBLE:
+                return rowData.getDouble(index);
+            case VARCHAR:
+            case CHAR:
+                return rowData.getString(index).toString();
+            case DECIMAL:
+                return rowData.getDecimal(
+                        index,
+                        ((org.apache.flink.table.types.logical.DecimalType) type).getPrecision(),
+                        ((org.apache.flink.table.types.logical.DecimalType) type).getScale());
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+            case TIMESTAMP_WITH_TIME_ZONE:
+                // Convert timestamp to string in ISO format
+                return rowData.getTimestamp(index, 3).toLocalDateTime().toString();
+            default:
+                // Fallback to string representation
+                return rowData.getString(index).toString();
+        }
+    }
+
+    private long convertToNanos(long timestamp) {
+        // Convert based on configured precision to nanoseconds
+        switch (fieldMapping.getSourceTimestampPrecision()) {
+            case PRECISION_NANOSECOND:
+                return timestamp;
+            case PRECISION_MICROSECOND:
+                return timestamp * 1000;
+            case PRECISION_MILLISECOND:
+                return timestamp * 1_000_000;
+            case PRECISION_SECOND:
+                return timestamp * 1_000_000_000;
+            default:
+                return timestamp * 1_000_000; // Default ms
+        }
+    }
+}

--- a/src/main/java/org/opengemini/flink/utils/EnhancedOpenGeminiClient.java
+++ b/src/main/java/org/opengemini/flink/utils/EnhancedOpenGeminiClient.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025 openGemini authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengemini.flink.utils;
+
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import io.opengemini.client.api.Configuration;
+import io.opengemini.client.api.OpenGeminiException;
+import io.opengemini.client.impl.OpenGeminiClient;
+
+public class EnhancedOpenGeminiClient extends OpenGeminiClient {
+    public EnhancedOpenGeminiClient(@NotNull Configuration conf) {
+        super(conf);
+    }
+
+    /**
+     * Write data to database using line protocol string.
+     *
+     * @param database the name of the database
+     * @param lineProtocol the line protocol string to write
+     * @return a CompletableFuture that completes when the write is done
+     * @throws OpenGeminiException if the write fails
+     */
+    public CompletableFuture<Void> writeLineProtocol(String database, String lineProtocol) {
+        return writeLineProtocol(database, null, lineProtocol);
+    }
+
+    /**
+     * Write data to database using line protocol string with specified retention policy.
+     *
+     * @param database the name of the database
+     * @param retentionPolicy the name of the retention policy (optional)
+     * @param lineProtocol the line protocol string to write
+     * @return a CompletableFuture that completes when the write is done
+     * @throws OpenGeminiException if the write fails
+     */
+    public CompletableFuture<Void> writeLineProtocol(
+            String database, String retentionPolicy, String lineProtocol) {
+        if (StringUtils.isBlank(database)) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.completeExceptionally(
+                    new IllegalArgumentException("Database name cannot be null or empty"));
+            return future;
+        }
+
+        if (StringUtils.isEmpty(lineProtocol)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return executeWrite(database, retentionPolicy, lineProtocol);
+    }
+
+    /**
+     * Write multiple line protocol strings to database.
+     *
+     * @param database the name of the database
+     * @param lineProtocols list of line protocol strings to write
+     * @return a CompletableFuture that completes when the write is done
+     * @throws OpenGeminiException if the write fails
+     */
+    public CompletableFuture<Void> writeLineProtocols(String database, List<String> lineProtocols) {
+        return writeLineProtocols(database, null, lineProtocols);
+    }
+
+    /**
+     * Write multiple line protocol strings to database with specified retention policy.
+     *
+     * @param database the name of the database
+     * @param retentionPolicy the name of the retention policy (optional)
+     * @param lineProtocols list of line protocol strings to write
+     * @return a CompletableFuture that completes when the write is done
+     * @throws OpenGeminiException if the write fails
+     */
+    public CompletableFuture<Void> writeLineProtocols(
+            String database, String retentionPolicy, List<String> lineProtocols) {
+        if (StringUtils.isBlank(database)) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.completeExceptionally(
+                    new IllegalArgumentException("Database name cannot be null or empty"));
+            return future;
+        }
+
+        if (lineProtocols == null || lineProtocols.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        StringJoiner sj = new StringJoiner("\n");
+        for (String lineProtocol : lineProtocols) {
+            if (StringUtils.isNotEmpty(lineProtocol)) {
+                // Trim each line to remove any extra whitespace
+                sj.add(lineProtocol.trim());
+            }
+        }
+
+        String body = sj.toString();
+        if (StringUtils.isEmpty(body)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return executeWrite(database, retentionPolicy, body);
+    }
+
+    /**
+     * Write batch data to database using a single line protocol string containing multiple lines.
+     * Each line in the string should represent a separate data point.
+     *
+     * @param database the name of the database
+     * @param retentionPolicy the name of the retention policy (optional)
+     * @param batchLineProtocol the batch line protocol string (multiple lines separated by \n)
+     * @return a CompletableFuture that completes when the write is done
+     * @throws OpenGeminiException if the write fails
+     */
+    public CompletableFuture<Void> writeBatchLineProtocol(
+            String database, String retentionPolicy, String batchLineProtocol) {
+        if (StringUtils.isBlank(database)) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.completeExceptionally(
+                    new IllegalArgumentException("Database name cannot be null or empty"));
+            return future;
+        }
+
+        if (StringUtils.isEmpty(batchLineProtocol)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        // Validate and clean up the batch line protocol
+        String[] lines = batchLineProtocol.split("\n");
+        StringJoiner cleanedBatch = new StringJoiner("\n");
+        for (String line : lines) {
+            String trimmedLine = line.trim();
+            if (StringUtils.isNotEmpty(trimmedLine)) {
+                cleanedBatch.add(trimmedLine);
+            }
+        }
+
+        String cleanedBody = cleanedBatch.toString();
+        if (StringUtils.isEmpty(cleanedBody)) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return executeWrite(database, retentionPolicy, cleanedBody);
+    }
+
+    /**
+     * Write batch data to database using a single line protocol string containing multiple lines.
+     * Uses the default retention policy.
+     *
+     * @param database the name of the database
+     * @param batchLineProtocol the batch line protocol string (multiple lines separated by \n)
+     * @return a CompletableFuture that completes when the write is done
+     * @throws OpenGeminiException if the write fails
+     */
+    public CompletableFuture<Void> writeBatchLineProtocol(
+            String database, String batchLineProtocol) {
+        return writeBatchLineProtocol(database, null, batchLineProtocol);
+    }
+
+    @Override
+    public String toString() {
+        return "EnhancedOpenGeminiClient{" + "httpEngine=" + conf.getHttpConfig().engine() + '}';
+    }
+}

--- a/src/main/java/org/opengemini/flink/utils/OpenGeminiClientFactory.java
+++ b/src/main/java/org/opengemini/flink/utils/OpenGeminiClientFactory.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 openGemini authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengemini.flink.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.opengemini.client.api.*;
+
+/**
+ * Factory class for creating OpenGemini client instances. Supports both standard and enhanced
+ * client creation.
+ */
+public class OpenGeminiClientFactory {
+
+    /**
+     * Create an enhanced OpenGeminiClient instance with line protocol support.
+     *
+     * @param configuration the client configuration
+     * @return a new EnhancedOpenGeminiClient instance
+     * @throws OpenGeminiException if configuration is invalid
+     */
+    public static EnhancedOpenGeminiClient createEnhanced(@NotNull Configuration configuration)
+            throws OpenGeminiException {
+        validateConfiguration(configuration);
+        return new EnhancedOpenGeminiClient(configuration);
+    }
+
+    /**
+     * Validate the configuration before creating a client.
+     *
+     * @param configuration the configuration to validate
+     * @throws OpenGeminiException if configuration is invalid
+     */
+    private static void validateConfiguration(@NotNull Configuration configuration)
+            throws OpenGeminiException {
+        // Validate addresses
+        if (configuration.getAddresses() == null || configuration.getAddresses().isEmpty()) {
+            throw new OpenGeminiException("must have at least one address");
+        }
+
+        // Validate auth configuration
+        AuthConfig authConfig = configuration.getAuthConfig();
+        if (authConfig != null) {
+            validateAuthConfig(authConfig);
+        }
+
+        // Validate batch configuration
+        BatchConfig batchConfig = configuration.getBatchConfig();
+        if (batchConfig != null) {
+            validateBatchConfig(batchConfig);
+        }
+    }
+
+    /**
+     * Validate authentication configuration.
+     *
+     * @param authConfig the authentication configuration to validate
+     * @throws OpenGeminiException if auth configuration is invalid
+     */
+    private static void validateAuthConfig(@NotNull AuthConfig authConfig)
+            throws OpenGeminiException {
+        if (authConfig.getAuthType() == AuthType.TOKEN) {
+            if (authConfig.getToken() == null || authConfig.getToken().isEmpty()) {
+                throw new OpenGeminiException("invalid auth config due to empty token");
+            }
+        }
+
+        if (authConfig.getAuthType() == AuthType.PASSWORD) {
+            if (authConfig.getUsername() == null || authConfig.getUsername().isEmpty()) {
+                throw new OpenGeminiException("invalid auth config due to empty username");
+            }
+            if (authConfig.getPassword() == null || authConfig.getPassword().length == 0) {
+                throw new OpenGeminiException("invalid auth config due to empty password");
+            }
+        }
+    }
+
+    /**
+     * Validate batch configuration.
+     *
+     * @param batchConfig the batch configuration to validate
+     * @throws OpenGeminiException if batch configuration is invalid
+     */
+    private static void validateBatchConfig(@NotNull BatchConfig batchConfig)
+            throws OpenGeminiException {
+        if (batchConfig.getBatchInterval() <= 0) {
+            throw new OpenGeminiException("batch enabled, batch interval must be great than 0");
+        }
+        if (batchConfig.getBatchSize() <= 0) {
+            throw new OpenGeminiException("batch enabled, batch size must be great than 0");
+        }
+    }
+}

--- a/src/test/java/org/opengemini/flink/sink/OpenGeminiSinkConfigurationTest.java
+++ b/src/test/java/org/opengemini/flink/sink/OpenGeminiSinkConfigurationTest.java
@@ -104,19 +104,6 @@ class OpenGeminiSinkConfigurationTest {
     }
 
     @Test
-    void testMissingConverterThrows() {
-        IllegalArgumentException ex =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () ->
-                                OpenGeminiSinkConfiguration.<String>builder()
-                                        .setDatabase("db")
-                                        .setMeasurement("m")
-                                        .build());
-        assertEquals("Converter must be provided", ex.getMessage());
-    }
-
-    @Test
     void testInvalidBatchSizeThrows() {
         IllegalArgumentException ex =
                 assertThrows(
@@ -202,18 +189,6 @@ class OpenGeminiSinkConfigurationTest {
                 IllegalArgumentException.class,
                 () -> OpenGeminiSinkConfiguration.<String>builder().setBatchSize(-1).build(),
                 "Batch size must be positive");
-    }
-
-    @Test
-    void testSetPointConverterAlias() {
-        OpenGeminiSinkConfiguration<String> config =
-                OpenGeminiSinkConfiguration.<String>builder()
-                        .setDatabase("db")
-                        .setMeasurement("m")
-                        .setPointConverter(mockConverter) // Using alias method
-                        .build();
-
-        assertEquals(mockConverter, config.getConverter());
     }
 
     @Test

--- a/src/test/java/org/opengemini/flink/sink/SimpleOpenGeminiLineProtocolConverterTest.java
+++ b/src/test/java/org/opengemini/flink/sink/SimpleOpenGeminiLineProtocolConverterTest.java
@@ -1,0 +1,644 @@
+/*
+ * Copyright 2025 openGemini authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengemini.flink.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Comprehensive unit tests for SimpleOpenGeminiLineProtocolConverter */
+public class SimpleOpenGeminiLineProtocolConverterTest {
+
+    // Test data class
+    static class TestData {
+        String tagValue;
+        String stringField;
+        Integer intField;
+        Long longField;
+        Float floatField;
+        Double doubleField;
+        Boolean boolField;
+        Long timestamp;
+        Instant instantTimestamp;
+
+        TestData() {}
+
+        TestData(String tagValue, String stringField, Integer intField) {
+            this.tagValue = tagValue;
+            this.stringField = stringField;
+            this.intField = intField;
+        }
+    }
+
+    @Nested
+    @DisplayName("Basic Conversion Tests")
+    class BasicConversionTests {
+
+        @Test
+        @DisplayName("Should convert simple object with all field types")
+        void testBasicConversion() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "server01";
+            data.stringField = "test";
+            data.intField = 42;
+            data.longField = 100L;
+            data.floatField = 3.14f;
+            data.doubleField = 2.718;
+            data.boolField = true;
+            data.timestamp = 1000000000L;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addField("stringField", d -> d.stringField)
+                            .addField("intField", d -> d.intField)
+                            .addField("longField", d -> d.longField)
+                            .addField("floatField", d -> d.floatField)
+                            .addField("doubleField", d -> d.doubleField)
+                            .addField("boolField", d -> d.boolField)
+                            .withTimestamp(d -> d.timestamp)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertNotNull(result);
+            assertTrue(result.startsWith("measurement,host=server01 "));
+            assertTrue(result.contains("stringField=\"test\""));
+            assertTrue(result.contains("intField=42i"));
+            assertTrue(result.contains("longField=100i"));
+            assertTrue(result.contains("floatField=3.14"));
+            assertTrue(result.contains("doubleField=2.718"));
+            assertTrue(result.contains("boolField=true"));
+            assertTrue(result.endsWith(" 1000000000"));
+        }
+
+        @Test
+        @DisplayName("Should handle null input value")
+        void testNullInputValue() {
+            // Arrange
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(null, "measurement");
+
+            // Assert
+            assertNull(result);
+        }
+
+        @Test
+        @DisplayName("Should return null when no fields have values")
+        void testNoFieldValues() {
+            // Arrange
+            TestData data = new TestData();
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field1", d -> d.stringField)
+                            .addField("field2", d -> d.intField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Special Character Escaping Tests")
+    class EscapingTests {
+
+        @Test
+        @DisplayName("Should escape spaces in tag values")
+        void testEscapeSpacesInTags() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "server 01";
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("host=server\\ 01"));
+        }
+
+        @Test
+        @DisplayName("Should escape commas in tag values")
+        void testEscapeCommasInTags() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "server,01";
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("host=server\\,01"));
+        }
+
+        @Test
+        @DisplayName("Should escape equals signs in tag values")
+        void testEscapeEqualsInTags() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "server=01";
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("host=server\\=01"));
+        }
+
+        @Test
+        @DisplayName("Should escape multiple special characters in tag values")
+        void testEscapeMultipleSpecialCharsInTags() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "server 01,region=us";
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("host=server\\ 01\\,region\\=us"));
+        }
+
+        @Test
+        @DisplayName("Should escape quotes in string field values")
+        void testEscapeQuotesInStringFields() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value with \"quotes\"";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("field=\"value with \\\"quotes\\\"\""));
+        }
+    }
+
+    @Nested
+    @DisplayName("Timestamp Tests")
+    class TimestampTests {
+
+        @Test
+        @DisplayName("Should use system nano time when no timestamp extractor provided")
+        void testDefaultTimestamp() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            long before = System.nanoTime();
+            String result = converter.convertToLineProtocol(data, "measurement");
+            long after = System.nanoTime();
+
+            // Assert
+            String[] parts = result.split(" ");
+            long timestamp = Long.parseLong(parts[parts.length - 1]);
+            assertTrue(timestamp >= before && timestamp <= after);
+        }
+
+        @Test
+        @DisplayName("Should use provided timestamp in nanoseconds")
+        void testProvidedTimestampNanos() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value";
+            data.timestamp = 1234567890L;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .withTimestamp(d -> d.timestamp)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.endsWith(" 1234567890"));
+        }
+
+        @Test
+        @DisplayName("Should convert milliseconds to nanoseconds")
+        void testTimestampMillisConversion() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value";
+            data.timestamp = 1000L; // 1000 milliseconds
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .withTimestampMillis(d -> d.timestamp)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.endsWith(" 1000000000")); // 1000 * 1_000_000
+        }
+
+        @Test
+        @DisplayName("Should convert Instant to nanoseconds")
+        void testTimestampInstantConversion() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value";
+            data.instantTimestamp = Instant.ofEpochMilli(1000L);
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .withTimestampInstant(d -> d.instantTimestamp)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.endsWith(" 1000000000"));
+        }
+
+        @Test
+        @DisplayName("Should handle null timestamp with default system time")
+        void testNullTimestamp() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value";
+            data.timestamp = null;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .withTimestamp(d -> d.timestamp)
+                            .build();
+
+            // Act
+            long before = System.nanoTime();
+            String result = converter.convertToLineProtocol(data, "measurement");
+            long after = System.nanoTime();
+
+            // Assert
+            String[] parts = result.split(" ");
+            long timestamp = Long.parseLong(parts[parts.length - 1]);
+            assertTrue(timestamp >= before && timestamp <= after);
+        }
+
+        @Test
+        @DisplayName("Should handle null Instant timestamp")
+        void testNullInstantTimestamp() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "value";
+            data.instantTimestamp = null;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .withTimestampInstant(d -> d.instantTimestamp)
+                            .build();
+
+            // Act
+            long before = System.nanoTime();
+            String result = converter.convertToLineProtocol(data, "measurement");
+            long after = System.nanoTime();
+
+            // Assert
+            String[] parts = result.split(" ");
+            long timestamp = Long.parseLong(parts[parts.length - 1]);
+            assertTrue(timestamp >= before && timestamp <= after);
+        }
+    }
+
+    @Nested
+    @DisplayName("Multiple Tags and Fields Tests")
+    class MultipleTagsFieldsTests {
+
+        @Test
+        @DisplayName("Should handle multiple tags in correct order")
+        void testMultipleTags() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "server01";
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addTag("region", d -> "us-west")
+                            .addTag("env", d -> "prod")
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("host=server01"));
+            assertTrue(result.contains("region=us-west"));
+            assertTrue(result.contains("env=prod"));
+        }
+
+        @Test
+        @DisplayName("Should handle multiple fields with different types")
+        void testMultipleFields() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = "text";
+            data.intField = 42;
+            data.boolField = false;
+            data.doubleField = 3.14;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("stringField", d -> d.stringField)
+                            .addField("intField", d -> d.intField)
+                            .addField("boolField", d -> d.boolField)
+                            .addField("doubleField", d -> d.doubleField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("stringField=\"text\""));
+            assertTrue(result.contains("intField=42i"));
+            assertTrue(result.contains("boolField=false"));
+            assertTrue(result.contains("doubleField=3.14"));
+        }
+
+        @Test
+        @DisplayName("Should skip null tag values")
+        void testNullTagValues() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = null;
+            data.stringField = "value";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addTag("region", d -> "us-west")
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertFalse(result.contains("host="));
+            assertTrue(result.contains("region=us-west"));
+        }
+
+        @Test
+        @DisplayName("Should skip null field values")
+        void testNullFieldValues() {
+            // Arrange
+            TestData data = new TestData();
+            data.stringField = null;
+            data.intField = 42;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("stringField", d -> d.stringField)
+                            .addField("intField", d -> d.intField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertFalse(result.contains("stringField="));
+            assertTrue(result.contains("intField=42i"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder Tests")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("Should throw exception when no fields defined")
+        void testBuilderNoFields() {
+            // Act & Assert
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> {
+                        SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                                .addTag("host", d -> d.tagValue)
+                                .build();
+                    });
+        }
+
+        @Test
+        @DisplayName("Should allow building with only fields")
+        void testBuilderOnlyFields() {
+            // Act
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Assert
+            assertNotNull(converter);
+        }
+
+        @Test
+        @DisplayName("Should support method chaining")
+        void testBuilderMethodChaining() {
+            // Act
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("tag1", d -> "value1")
+                            .addTag("tag2", d -> "value2")
+                            .addField("field1", d -> "value1")
+                            .addField("field2", d -> 42)
+                            .withTimestamp(d -> 1000L)
+                            .build();
+
+            // Assert
+            assertNotNull(converter);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases and Special Values Tests")
+    class EdgeCasesTests {
+
+        @Test
+        @DisplayName("Should handle empty string values")
+        void testEmptyStringValues() {
+            // Arrange
+            TestData data = new TestData();
+            data.tagValue = "";
+            data.stringField = "";
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addTag("host", d -> d.tagValue)
+                            .addField("field", d -> d.stringField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("host="));
+            assertTrue(result.contains("field=\"\""));
+        }
+
+        @Test
+        @DisplayName("Should handle very large numbers")
+        void testLargeNumbers() {
+            // Arrange
+            TestData data = new TestData();
+            data.longField = Long.MAX_VALUE;
+            data.doubleField = Double.MAX_VALUE;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("longField", d -> d.longField)
+                            .addField("doubleField", d -> d.doubleField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("longField=" + Long.MAX_VALUE + "i"));
+            assertTrue(result.contains("doubleField=" + Double.MAX_VALUE));
+        }
+
+        @Test
+        @DisplayName("Should handle negative numbers")
+        void testNegativeNumbers() {
+            // Arrange
+            TestData data = new TestData();
+            data.intField = -42;
+            data.floatField = -3.14f;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("intField", d -> d.intField)
+                            .addField("floatField", d -> d.floatField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("intField=-42i"));
+            assertTrue(result.contains("floatField=-3.14"));
+        }
+
+        @Test
+        @DisplayName("Should handle zero values")
+        void testZeroValues() {
+            // Arrange
+            TestData data = new TestData();
+            data.intField = 0;
+            data.doubleField = 0.0;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("intField", d -> d.intField)
+                            .addField("doubleField", d -> d.doubleField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("intField=0i"));
+            assertTrue(result.contains("doubleField=0.0"));
+        }
+
+        @Test
+        @DisplayName("Should handle special float values")
+        void testSpecialFloatValues() {
+            // Arrange
+            TestData data = new TestData();
+            data.floatField = Float.NaN;
+            data.doubleField = Double.POSITIVE_INFINITY;
+
+            SimpleOpenGeminiLineProtocolConverter<TestData> converter =
+                    SimpleOpenGeminiLineProtocolConverter.<TestData>builder()
+                            .addField("floatField", d -> d.floatField)
+                            .addField("doubleField", d -> d.doubleField)
+                            .build();
+
+            // Act
+            String result = converter.convertToLineProtocol(data, "measurement");
+
+            // Assert
+            assertTrue(result.contains("floatField=NaN"));
+            assertTrue(result.contains("doubleField=Infinity"));
+        }
+    }
+}

--- a/src/test/java/org/opengemini/flink/sink/SimpleOpenGeminiPointConverterTest.java
+++ b/src/test/java/org/opengemini/flink/sink/SimpleOpenGeminiPointConverterTest.java
@@ -48,7 +48,7 @@ class SimpleOpenGeminiPointConverterTest {
                 SimpleOpenGeminiPointConverter.<TestData>builder()
                         .addField("f", d -> d.field)
                         .build();
-        assertNull(converter.convert(null, "m"));
+        assertNull(converter.convertToPoint(null, "m"));
     }
 
     @Test
@@ -68,7 +68,7 @@ class SimpleOpenGeminiPointConverterTest {
                         .addField("field1", dd -> dd.field)
                         .build();
 
-        Point p = converter.convert(t, "measurement1");
+        Point p = converter.convertToPoint(t, "measurement1");
         assertNotNull(p);
         assertEquals("measurement1", p.getMeasurement());
         Map<String, String> tags = p.getTags();
@@ -88,7 +88,7 @@ class SimpleOpenGeminiPointConverterTest {
                         .addField("f", dd -> dd.field)
                         .build();
 
-        Point p = converter.convert(t, "m");
+        Point p = converter.convertToPoint(t, "m");
         assertNotNull(p);
         assertNull(p.getTags());
         assertEquals(Collections.singletonMap("f", 100), p.getFields());
@@ -103,7 +103,7 @@ class SimpleOpenGeminiPointConverterTest {
                         .withTimestampMillis(dd -> dd.timestampMillis)
                         .build();
 
-        Point p = converter.convert(t, "m");
+        Point p = converter.convertToPoint(t, "m");
         assertEquals(12345L * 1_000_000L, p.getTime());
     }
 
@@ -117,7 +117,7 @@ class SimpleOpenGeminiPointConverterTest {
                         .withTimestampInstant(dd -> dd.timestampInstant)
                         .build();
 
-        Point p = converter.convert(t, "m");
+        Point p = converter.convertToPoint(t, "m");
         assertEquals(9999L * 1_000_000L, p.getTime());
     }
 
@@ -134,7 +134,8 @@ class SimpleOpenGeminiPointConverterTest {
                         .addField("f", dd -> dd.field)
                         .build();
 
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.convert(t, "m"));
+        RuntimeException ex =
+                assertThrows(RuntimeException.class, () -> converter.convertToPoint(t, "m"));
         assertTrue(ex.getMessage().contains("Error extracting tag badTag"));
     }
 
@@ -150,7 +151,8 @@ class SimpleOpenGeminiPointConverterTest {
                         .addField("badField", badField)
                         .build();
 
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> converter.convert(t, "m"));
+        RuntimeException ex =
+                assertThrows(RuntimeException.class, () -> converter.convertToPoint(t, "m"));
         assertTrue(ex.getMessage().contains("Error extracting field badField"));
     }
 
@@ -162,6 +164,6 @@ class SimpleOpenGeminiPointConverterTest {
                         .addField("f", dd -> null)
                         .build();
 
-        assertNull(converter.convert(t, "m"));
+        assertNull(converter.convertToPoint(t, "m"));
     }
 }

--- a/src/test/java/org/opengemini/flink/table/ConverterTypeSelectionTest.java
+++ b/src/test/java/org/opengemini/flink/table/ConverterTypeSelectionTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2025 openGemini authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengemini.flink.table;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.*;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.*;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opengemini.flink.sink.OpenGeminiSinkConfiguration;
+import org.opengemini.flink.table.OpenGeminiDynamicTableSink.RowDataToLineProtocolConverter;
+import org.opengemini.flink.table.OpenGeminiDynamicTableSink.RowDataToPointConverter;
+import org.opengemini.flink.table.OpenGeminiDynamicTableSinkFactory.FieldMappingConfig;
+
+import io.opengemini.client.api.Point;
+
+/** Tests for converter type selection in OpenGeminiDynamicTableSink */
+public class ConverterTypeSelectionTest {
+
+    private OpenGeminiDynamicTableSinkFactory factory;
+    private ResolvedSchema resolvedSchema;
+
+    @BeforeEach
+    void setUp() {
+        factory = new OpenGeminiDynamicTableSinkFactory();
+
+        // Create a simple schema for testing
+        Column col1 = Column.physical("id", DataTypes.INT());
+        Column col2 = Column.physical("name", DataTypes.STRING());
+        Column col3 = Column.physical("value", DataTypes.DOUBLE());
+        List<Column> columns = Arrays.asList(col1, col2, col3);
+
+        resolvedSchema = ResolvedSchema.of(columns);
+    }
+
+    @Test
+    @DisplayName("Should create sink with line-protocol converter by default")
+    void testDefaultConverterTypeIsLineProtocol() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "opengemini");
+        options.put("host", "localhost");
+        options.put("database", "testdb");
+        options.put("measurement", "test_measurement");
+        // Not specifying converter.type, should use default
+
+        DynamicTableSinkFactory.Context context = createMockContext(options);
+        DynamicTableSink sink = factory.createDynamicTableSink(context);
+
+        assertNotNull(sink);
+        assertTrue(sink instanceof OpenGeminiDynamicTableSink);
+
+        // Verify it creates the correct runtime provider
+        OpenGeminiDynamicTableSink openGeminiSink = (OpenGeminiDynamicTableSink) sink;
+        DynamicTableSink.Context sinkContext = mock(DynamicTableSink.Context.class);
+        DynamicTableSink.SinkRuntimeProvider provider =
+                openGeminiSink.getSinkRuntimeProvider(sinkContext);
+
+        assertNotNull(provider);
+        assertTrue(provider instanceof SinkFunctionProvider);
+    }
+
+    @Test
+    @DisplayName("Should create sink with line-protocol converter when explicitly specified")
+    void testExplicitLineProtocolConverter() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "opengemini");
+        options.put("host", "localhost");
+        options.put("database", "testdb");
+        options.put("measurement", "test_measurement");
+        options.put("converter.type", "line-protocol");
+
+        DynamicTableSinkFactory.Context context = createMockContext(options);
+        DynamicTableSink sink = factory.createDynamicTableSink(context);
+
+        assertNotNull(sink);
+        assertTrue(sink instanceof OpenGeminiDynamicTableSink);
+    }
+
+    @Test
+    @DisplayName("Should create sink with point converter when specified")
+    void testPointConverter() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "opengemini");
+        options.put("host", "localhost");
+        options.put("database", "testdb");
+        options.put("measurement", "test_measurement");
+        options.put("converter.type", "point");
+
+        DynamicTableSinkFactory.Context context = createMockContext(options);
+        DynamicTableSink sink = factory.createDynamicTableSink(context);
+
+        assertNotNull(sink);
+        assertTrue(sink instanceof OpenGeminiDynamicTableSink);
+
+        // Verify it creates the correct runtime provider
+        OpenGeminiDynamicTableSink openGeminiSink = (OpenGeminiDynamicTableSink) sink;
+        DynamicTableSink.Context sinkContext = mock(DynamicTableSink.Context.class);
+        DynamicTableSink.SinkRuntimeProvider provider =
+                openGeminiSink.getSinkRuntimeProvider(sinkContext);
+
+        assertNotNull(provider);
+        assertTrue(provider instanceof SinkFunctionProvider);
+    }
+
+    @Test
+    @DisplayName("Should verify both converters produce semantically equivalent output")
+    void testConverterEquivalence() {
+        // Setup schema
+        List<String> columnNames = Arrays.asList("host", "cpu", "usage");
+        List<DataType> columnTypes =
+                Arrays.asList(DataTypes.STRING(), DataTypes.STRING(), DataTypes.DOUBLE());
+
+        ResolvedSchema schema = mock(ResolvedSchema.class);
+        when(schema.getColumnNames()).thenReturn(columnNames);
+        when(schema.getColumnDataTypes()).thenReturn(columnTypes);
+
+        FieldMappingConfig fieldMapping = FieldMappingConfig.builder().addTagField("host").build();
+
+        // Create both converters
+        RowDataToPointConverter pointConverter =
+                new RowDataToPointConverter(schema, fieldMapping, "cpu_metrics");
+        RowDataToLineProtocolConverter lineProtocolConverter =
+                new RowDataToLineProtocolConverter(schema, fieldMapping, "cpu_metrics");
+
+        // Test data
+        GenericRowData row =
+                GenericRowData.of(
+                        StringData.fromString("server01"), StringData.fromString("cpu0"), 75.5);
+        row.setRowKind(RowKind.INSERT);
+
+        // Convert with both converters
+        Point point = pointConverter.convertToPoint(row, "cpu_metrics");
+        String lineProtocol = lineProtocolConverter.convertToLineProtocol(row, "cpu_metrics");
+
+        // Verify Point converter output
+        assertNotNull(point);
+        assertEquals("cpu_metrics", point.getMeasurement());
+        assertEquals("server01", point.getTags().get("host"));
+        assertEquals("cpu0", point.getFields().get("cpu"));
+        assertEquals(75.5, point.getFields().get("usage"));
+
+        // Verify Line Protocol converter output
+        assertNotNull(lineProtocol);
+        assertTrue(lineProtocol.startsWith("cpu_metrics,host=server01 "));
+        assertTrue(lineProtocol.contains("cpu=\"cpu0\""));
+        assertTrue(lineProtocol.contains("usage=75.5"));
+    }
+
+    @Test
+    @DisplayName("Should handle all row kinds consistently across converters")
+    void testRowKindHandlingAcrossConverters() {
+        // Setup schema
+        List<String> columnNames = Arrays.asList("value");
+        List<DataType> columnTypes = Arrays.asList(DataTypes.INT());
+
+        ResolvedSchema schema = mock(ResolvedSchema.class);
+        when(schema.getColumnNames()).thenReturn(columnNames);
+        when(schema.getColumnDataTypes()).thenReturn(columnTypes);
+
+        FieldMappingConfig fieldMapping = FieldMappingConfig.builder().build();
+
+        RowDataToPointConverter pointConverter =
+                new RowDataToPointConverter(schema, fieldMapping, "test");
+        RowDataToLineProtocolConverter lineProtocolConverter =
+                new RowDataToLineProtocolConverter(schema, fieldMapping, "test");
+
+        // Test all row kinds
+        RowKind[] rowKinds = {
+            RowKind.INSERT, RowKind.UPDATE_AFTER, RowKind.DELETE, RowKind.UPDATE_BEFORE
+        };
+
+        for (RowKind rowKind : rowKinds) {
+            GenericRowData row = GenericRowData.of(42);
+            row.setRowKind(rowKind);
+
+            Point point = pointConverter.convertToPoint(row, "test");
+            String lineProtocol = lineProtocolConverter.convertToLineProtocol(row, "test");
+
+            if (rowKind == RowKind.INSERT || rowKind == RowKind.UPDATE_AFTER) {
+                // Both converters should produce output
+                assertNotNull(point, "Point converter should produce output for " + rowKind);
+                assertNotNull(
+                        lineProtocol,
+                        "Line protocol converter should produce output for " + rowKind);
+            } else {
+                // Both converters should return null
+                assertNull(point, "Point converter should return null for " + rowKind);
+                assertNull(
+                        lineProtocol, "Line protocol converter should return null for " + rowKind);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Should copy sink with correct converter type")
+    void testSinkCopyPreservesConverterType() {
+        OpenGeminiSinkConfiguration<RowData> config = mock(OpenGeminiSinkConfiguration.class);
+        when(config.getMeasurement()).thenReturn("test");
+
+        // Create sink with line-protocol converter
+        OpenGeminiDynamicTableSink originalSink =
+                new OpenGeminiDynamicTableSink(
+                        config,
+                        resolvedSchema,
+                        FieldMappingConfig.builder().build(),
+                        2,
+                        "line-protocol");
+
+        DynamicTableSink copiedSink = originalSink.copy();
+
+        assertNotNull(copiedSink);
+        assertTrue(copiedSink instanceof OpenGeminiDynamicTableSink);
+        assertNotSame(originalSink, copiedSink);
+
+        // Create sink with point converter
+        OpenGeminiDynamicTableSink originalPointSink =
+                new OpenGeminiDynamicTableSink(
+                        config, resolvedSchema, FieldMappingConfig.builder().build(), 2, "point");
+
+        DynamicTableSink copiedPointSink = originalPointSink.copy();
+
+        assertNotNull(copiedPointSink);
+        assertTrue(copiedPointSink instanceof OpenGeminiDynamicTableSink);
+        assertNotSame(originalPointSink, copiedPointSink);
+    }
+
+    @Test
+    @DisplayName("Should handle null converter type as default")
+    void testNullConverterTypeUsesDefault() {
+        OpenGeminiSinkConfiguration<RowData> config = mock(OpenGeminiSinkConfiguration.class);
+        when(config.getMeasurement()).thenReturn("test");
+        when(config.toBuilder()).thenReturn(mock(OpenGeminiSinkConfiguration.Builder.class));
+
+        // Pass null as converter type
+        OpenGeminiDynamicTableSink sink =
+                new OpenGeminiDynamicTableSink(
+                        config, resolvedSchema, FieldMappingConfig.builder().build(), null, null);
+
+        assertNotNull(sink);
+        // Should use default converter type (line-protocol)
+        String summary = sink.asSummaryString();
+        assertNotNull(summary);
+    }
+
+    // Helper method to create mock context
+    private DynamicTableSinkFactory.Context createMockContext(Map<String, String> options) {
+        DynamicTableSinkFactory.Context context = mock(DynamicTableSinkFactory.Context.class);
+
+        // Mock ObjectIdentifier
+        ObjectIdentifier identifier =
+                ObjectIdentifier.of("default_catalog", "default_database", "test_table");
+        when(context.getObjectIdentifier()).thenReturn(identifier);
+
+        // Mock Configuration
+        Configuration configuration = Configuration.fromMap(options);
+        when(context.getConfiguration()).thenReturn(configuration);
+
+        // Mock CatalogTable with ResolvedSchema
+        ResolvedCatalogTable catalogTable = mock(ResolvedCatalogTable.class);
+        when(catalogTable.getResolvedSchema()).thenReturn(resolvedSchema);
+        when(catalogTable.getOptions()).thenReturn(options);
+        when(catalogTable.getPartitionKeys()).thenReturn(Collections.emptyList());
+        when(context.getCatalogTable()).thenReturn(catalogTable);
+
+        // Mock ClassLoader
+        when(context.getClassLoader()).thenReturn(Thread.currentThread().getContextClassLoader());
+        when(context.isTemporary()).thenReturn(false);
+
+        return context;
+    }
+}

--- a/src/test/java/org/opengemini/flink/table/OpenGeminiDynamicTableSinkFactoryTest.java
+++ b/src/test/java/org/opengemini/flink/table/OpenGeminiDynamicTableSinkFactoryTest.java
@@ -88,7 +88,7 @@ class OpenGeminiDynamicTableSinkFactoryTest {
                 (OpenGeminiDynamicTableSinkFactory.FieldMappingConfig) result;
 
         assertEquals("event_time", fm.getTimestampField());
-        assertEquals("us", fm.getWritePrecision());
+        assertEquals("us", fm.getSourceTimestampPrecision());
         assertFalse(fm.isIgnoreNullValues());
 
         // tags and fields sets should contain trimmed values
@@ -193,14 +193,14 @@ class OpenGeminiDynamicTableSinkFactoryTest {
                         .addTagField("tag2")
                         .addFieldField("field1")
                         .ignoreNullValues(false)
-                        .writePrecision("us")
+                        .sourceTimestampPrecision("us")
                         .build();
 
         assertEquals("ts", config.getTimestampField());
         assertEquals(2, config.getTagFields().size());
         assertTrue(config.getTagFields().contains("tag1"));
         assertFalse(config.isIgnoreNullValues());
-        assertEquals("us", config.getWritePrecision());
+        assertEquals("us", config.getSourceTimestampPrecision());
     }
 
     @Test
@@ -213,7 +213,7 @@ class OpenGeminiDynamicTableSinkFactoryTest {
         assertTrue(config.getTagFields().isEmpty());
         assertTrue(config.getFieldFields().isEmpty());
         assertTrue(config.isIgnoreNullValues()); // Default is true
-        assertEquals("ms", config.getWritePrecision()); // Default is "ms"
+        assertEquals("ms", config.getSourceTimestampPrecision()); // Default is "ms"
     }
 
     @Test
@@ -249,7 +249,7 @@ class OpenGeminiDynamicTableSinkFactoryTest {
         options.put("tag-fields", "tag1,tag2");
         options.put("field-fields", "field1,field2");
         options.put("ignore-null-values", "false");
-        options.put("write-precision", "ns");
+        options.put("source-precision", "ns");
 
         DynamicTableSinkFactory.Context context = createCompleteMockContext(options);
 
@@ -280,6 +280,6 @@ class OpenGeminiDynamicTableSinkFactoryTest {
         assertTrue(fm.getTagFields().isEmpty());
         assertTrue(fm.getFieldFields().isEmpty());
         assertTrue(fm.isIgnoreNullValues()); // Default value
-        assertEquals("ms", fm.getWritePrecision()); // Default value
+        assertEquals("ms", fm.getSourceTimestampPrecision()); // Default value
     }
 }

--- a/src/test/java/org/opengemini/flink/table/RowDataToLineProtocolConverterTest.java
+++ b/src/test/java/org/opengemini/flink/table/RowDataToLineProtocolConverterTest.java
@@ -1,0 +1,654 @@
+/*
+ * Copyright 2025 openGemini authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengemini.flink.table;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.opengemini.flink.table.OpenGeminiDynamicTableSink.RowDataToLineProtocolConverter;
+import org.opengemini.flink.table.OpenGeminiDynamicTableSinkFactory.FieldMappingConfig;
+
+/** Core tests for RowDataToLineProtocolConverter focusing on the most critical functionality */
+public class RowDataToLineProtocolConverterTest {
+
+    private ResolvedSchema resolvedSchema;
+
+    @BeforeEach
+    void setUp() {
+        resolvedSchema = mock(ResolvedSchema.class);
+    }
+
+    @Nested
+    @DisplayName("Basic Line Protocol Generation")
+    class BasicLineProtocolTests {
+
+        @Test
+        @DisplayName("Should generate valid line protocol with all components")
+        void testCompleteLineProtocol() {
+            // Setup schema: measurement,tag1=value1,tag2=value2
+            // field1="string",field2=42i,field3=3.14 timestamp
+            List<String> columnNames =
+                    Arrays.asList("host", "region", "message", "value", "temperature", "ts");
+            List<DataType> columnTypes =
+                    Arrays.asList(
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.INT(),
+                            DataTypes.DOUBLE(),
+                            DataTypes.BIGINT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm =
+                    FieldMappingConfig.builder()
+                            .addTagField("host")
+                            .addTagField("region")
+                            .timestampField("ts")
+                            .sourceTimestampPrecision("ms")
+                            .build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "cpu");
+
+            GenericRowData row =
+                    GenericRowData.of(
+                            StringData.fromString("server01"),
+                            StringData.fromString("us-west"),
+                            StringData.fromString("Hello World"),
+                            42,
+                            3.14,
+                            1609459200000L // 2021-01-01 00:00:00 in millis
+                            );
+            row.setRowKind(RowKind.INSERT);
+
+            // Act
+            String lineProtocol = converter.convertToLineProtocol(row, "cpu");
+
+            // Assert - verify the format: measurement,tags fields timestamp
+            assertNotNull(lineProtocol);
+
+            // Should start with measurement and tags
+            assertTrue(lineProtocol.startsWith("cpu,host=server01,region=us-west "));
+
+            // Should contain fields
+            assertTrue(lineProtocol.contains("message=\"Hello World\""));
+            assertTrue(lineProtocol.contains("value=42i"));
+            assertTrue(lineProtocol.contains("temperature=3.14"));
+
+            // Should end with timestamp
+            assertTrue(lineProtocol.endsWith(" 1609459200000000000"));
+
+            // Validate complete format with regex
+            String regex =
+                    "^cpu,host=server01,region=us-west (message=\"Hello World\",value=42i,temperature=3.14|"
+                            + "message=\"Hello World\",temperature=3.14,value=42i|"
+                            + "value=42i,message=\"Hello World\",temperature=3.14|"
+                            + "value=42i,temperature=3.14,message=\"Hello World\"|"
+                            + "temperature=3.14,message=\"Hello World\",value=42i|"
+                            + "temperature=3.14,value=42i,message=\"Hello World\") 1609459200000000000$";
+            System.out.println(lineProtocol);
+            assertTrue(Pattern.matches(regex, lineProtocol));
+        }
+
+        @Test
+        @DisplayName("Should handle measurement without tags")
+        void testNoTags() {
+            List<String> columnNames = Arrays.asList("value", "count");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.DOUBLE(), DataTypes.BIGINT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "metrics");
+
+            GenericRowData row = GenericRowData.of(99.9, 1000L);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "metrics");
+
+            // Should not have comma after measurement name
+            assertTrue(lineProtocol.startsWith("metrics "));
+            assertFalse(lineProtocol.startsWith("metrics,"));
+            assertTrue(lineProtocol.contains("value=99.9"));
+            assertTrue(lineProtocol.contains("count=1000i"));
+        }
+
+        @Test
+        @DisplayName("Should add _empty=true when no fields have values")
+        void testEmptyFields() {
+            List<String> columnNames = Arrays.asList("tag1", "field1");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.STRING(), DataTypes.STRING());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm =
+                    FieldMappingConfig.builder()
+                            .addTagField("tag1")
+                            .addFieldField("field1")
+                            .build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, StringData.fromString("tag_value"));
+            row.setField(1, null); // null field
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            assertTrue(lineProtocol.contains("_empty=true"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Special Character Escaping")
+    class EscapingTests {
+
+        @Test
+        @DisplayName("Should escape spaces, commas, and equals in tag values")
+        void testTagEscaping() {
+            List<String> columnNames =
+                    Arrays.asList("tag_with_space", "tag_with_comma", "tag_with_equals", "value");
+            List<DataType> columnTypes =
+                    Arrays.asList(
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.STRING(),
+                            DataTypes.INT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm =
+                    FieldMappingConfig.builder()
+                            .addTagField("tag_with_space")
+                            .addTagField("tag_with_comma")
+                            .addTagField("tag_with_equals")
+                            .build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row =
+                    GenericRowData.of(
+                            StringData.fromString("server 01"),
+                            StringData.fromString("region,east"),
+                            StringData.fromString("key=value"),
+                            100);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            // Verify escaping
+            assertTrue(lineProtocol.contains("tag_with_space=server\\ 01"));
+            assertTrue(lineProtocol.contains("tag_with_comma=region\\,east"));
+            assertTrue(lineProtocol.contains("tag_with_equals=key\\=value"));
+        }
+
+        @Test
+        @DisplayName("Should escape quotes in string field values")
+        void testStringFieldQuoteEscaping() {
+            List<String> columnNames = Arrays.asList("message", "description");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.STRING(), DataTypes.STRING());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "logs");
+
+            GenericRowData row =
+                    GenericRowData.of(
+                            StringData.fromString("He said \"Hello\""),
+                            StringData.fromString("Contains \"multiple\" quotes"));
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "logs");
+
+            // Verify quote escaping in fields
+            assertTrue(lineProtocol.contains("message=\"He said \\\"Hello\\\"\""));
+            assertTrue(lineProtocol.contains("description=\"Contains \\\"multiple\\\" quotes\""));
+        }
+
+        @Test
+        @DisplayName("Should handle complex escaping combinations")
+        void testComplexEscaping() {
+            List<String> columnNames = Arrays.asList("complex_tag", "complex_field");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.STRING(), DataTypes.STRING());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().addTagField("complex_tag").build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row =
+                    GenericRowData.of(
+                            StringData.fromString("tag with space, comma=equals"),
+                            StringData.fromString("field with \"quotes\" and spaces"));
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            // All special chars should be escaped in tag
+            assertTrue(lineProtocol.contains("complex_tag=tag\\ with\\ space\\,\\ comma\\=equals"));
+            // Quotes should be escaped in field
+            assertTrue(
+                    lineProtocol.contains(
+                            "complex_field=\"field with \\\"quotes\\\" and spaces\""));
+        }
+    }
+
+    @Nested
+    @DisplayName("Data Type Formatting")
+    class DataTypeFormattingTests {
+
+        @Test
+        @DisplayName("Should format all numeric types correctly")
+        void testNumericTypeFormatting() {
+            List<String> columnNames =
+                    Arrays.asList(
+                            "bool_field",
+                            "byte_field",
+                            "short_field",
+                            "int_field",
+                            "long_field",
+                            "float_field",
+                            "double_field",
+                            "decimal_field");
+            List<DataType> columnTypes =
+                    Arrays.asList(
+                            DataTypes.BOOLEAN(),
+                            DataTypes.TINYINT(),
+                            DataTypes.SMALLINT(),
+                            DataTypes.INT(),
+                            DataTypes.BIGINT(),
+                            DataTypes.FLOAT(),
+                            DataTypes.DOUBLE(),
+                            DataTypes.DECIMAL(10, 2));
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "numbers");
+
+            GenericRowData row =
+                    GenericRowData.of(
+                            true,
+                            (byte) 1,
+                            (short) 10,
+                            100,
+                            1000L,
+                            3.14f,
+                            2.718,
+                            DecimalData.fromBigDecimal(new BigDecimal("123.45"), 10, 2));
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "numbers");
+
+            // Boolean - no suffix
+            assertTrue(lineProtocol.contains("bool_field=true"));
+
+            // Integer types - should have 'i' suffix
+            assertTrue(lineProtocol.contains("byte_field=1i"));
+            assertTrue(lineProtocol.contains("short_field=10i"));
+            assertTrue(lineProtocol.contains("int_field=100i"));
+            assertTrue(lineProtocol.contains("long_field=1000i"));
+
+            // Float/Double - no suffix
+            assertTrue(lineProtocol.contains("float_field=3.14"));
+            assertTrue(lineProtocol.contains("double_field=2.718"));
+
+            // Decimal should be formatted as string
+            assertTrue(lineProtocol.contains("decimal_field=\"123.45\""));
+        }
+
+        @Test
+        @DisplayName("Should handle special float values")
+        void testSpecialFloatValues() {
+            List<String> columnNames = Arrays.asList("nan_field", "inf_field", "neg_inf_field");
+            List<DataType> columnTypes =
+                    Arrays.asList(DataTypes.FLOAT(), DataTypes.DOUBLE(), DataTypes.DOUBLE());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "special");
+
+            GenericRowData row =
+                    GenericRowData.of(
+                            Float.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "special");
+
+            assertTrue(lineProtocol.contains("nan_field=NaN"));
+            assertTrue(lineProtocol.contains("inf_field=Infinity"));
+            assertTrue(lineProtocol.contains("neg_inf_field=-Infinity"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Row Kind Handling")
+    class RowKindTests {
+
+        @Test
+        @DisplayName("Should return null for DELETE rows")
+        void testDeleteRowReturnsNull() {
+            List<String> columnNames = Arrays.asList("value");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.STRING());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = GenericRowData.of(StringData.fromString("test"));
+            row.setRowKind(RowKind.DELETE);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+            assertNull(lineProtocol);
+        }
+
+        @Test
+        @DisplayName("Should return null for UPDATE_BEFORE rows")
+        void testUpdateBeforeRowReturnsNull() {
+            List<String> columnNames = Arrays.asList("value");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.STRING());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = GenericRowData.of(StringData.fromString("test"));
+            row.setRowKind(RowKind.UPDATE_BEFORE);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+            assertNull(lineProtocol);
+        }
+
+        @Test
+        @DisplayName("Should process INSERT and UPDATE_AFTER rows")
+        void testInsertAndUpdateAfterRows() {
+            List<String> columnNames = Arrays.asList("value");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.INT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            // Test INSERT
+            GenericRowData insertRow = GenericRowData.of(42);
+            insertRow.setRowKind(RowKind.INSERT);
+            String insertProtocol = converter.convertToLineProtocol(insertRow, "test");
+            assertNotNull(insertProtocol);
+            assertTrue(insertProtocol.contains("value=42i"));
+
+            // Test UPDATE_AFTER
+            GenericRowData updateRow = GenericRowData.of(43);
+            updateRow.setRowKind(RowKind.UPDATE_AFTER);
+            String updateProtocol = converter.convertToLineProtocol(updateRow, "test");
+            assertNotNull(updateProtocol);
+            assertTrue(updateProtocol.contains("value=43i"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Timestamp Handling")
+    class TimestampTests {
+
+        @Test
+        @DisplayName("Should use current time when no timestamp field specified")
+        void testDefaultTimestamp() {
+            List<String> columnNames = Arrays.asList("value");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.INT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = GenericRowData.of(42);
+            row.setRowKind(RowKind.INSERT);
+
+            long before = System.currentTimeMillis();
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+            long after = System.currentTimeMillis();
+
+            // Extract timestamp from line protocol
+            String[] parts = lineProtocol.split(" ");
+            long timestamp = Long.parseLong(parts[parts.length - 1]);
+
+            assertTrue(timestamp >= before && timestamp <= after + 100);
+        }
+
+        @Test
+        @DisplayName("Should use specified timestamp field")
+        void testSpecifiedTimestamp() {
+            List<String> columnNames = Arrays.asList("value", "event_time");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.INT(), DataTypes.BIGINT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm =
+                    FieldMappingConfig.builder()
+                            .timestampField("event_time")
+                            .sourceTimestampPrecision("ms")
+                            .build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = GenericRowData.of(42, 1756080005L);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+            assertTrue(lineProtocol.endsWith(" 1756080005000000"));
+        }
+
+        @Test
+        @DisplayName("Should handle TIMESTAMP data type")
+        void testTimestampDataType() {
+            List<String> columnNames = Arrays.asList("value", "ts");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.INT(), DataTypes.TIMESTAMP(3));
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm =
+                    FieldMappingConfig.builder()
+                            .timestampField("ts")
+                            .sourceTimestampPrecision("ms")
+                            .build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            TimestampData timestamp = TimestampData.fromEpochMillis(1609459200000L);
+            GenericRowData row = GenericRowData.of(42, timestamp);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            assertTrue(lineProtocol.endsWith(" 1609459200000"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Null Value Handling")
+    class NullHandlingTests {
+
+        @Test
+        @DisplayName("Should skip null fields")
+        void testNullFieldsSkipped() {
+            List<String> columnNames = Arrays.asList("field1", "field2", "field3");
+            List<DataType> columnTypes =
+                    Arrays.asList(DataTypes.STRING(), DataTypes.INT(), DataTypes.DOUBLE());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = new GenericRowData(3);
+            row.setField(0, StringData.fromString("value1"));
+            row.setField(1, null); // null int
+            row.setField(2, 3.14);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            assertTrue(lineProtocol.contains("field1=\"value1\""));
+            assertFalse(lineProtocol.contains("field2="));
+            assertTrue(lineProtocol.contains("field3=3.14"));
+        }
+
+        @Test
+        @DisplayName("Should skip null tags")
+        void testNullTagsSkipped() {
+            List<String> columnNames = Arrays.asList("tag1", "tag2", "value");
+            List<DataType> columnTypes =
+                    Arrays.asList(DataTypes.STRING(), DataTypes.STRING(), DataTypes.INT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm =
+                    FieldMappingConfig.builder().addTagField("tag1").addTagField("tag2").build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row = new GenericRowData(3);
+            row.setField(0, null); // null tag
+            row.setField(1, StringData.fromString("tag2_value"));
+            row.setField(2, 42);
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            assertFalse(lineProtocol.contains("tag1="));
+            assertTrue(lineProtocol.contains("tag2=tag2_value"));
+            assertTrue(lineProtocol.contains("value=42i"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Integration and Edge Cases")
+    class IntegrationTests {
+
+        @Test
+        @DisplayName("Should handle empty string values")
+        void testEmptyStringValues() {
+            List<String> columnNames = Arrays.asList("empty_tag", "empty_field");
+            List<DataType> columnTypes = Arrays.asList(DataTypes.STRING(), DataTypes.STRING());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().addTagField("empty_tag").build();
+
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            GenericRowData row =
+                    GenericRowData.of(StringData.fromString(""), StringData.fromString(""));
+            row.setRowKind(RowKind.INSERT);
+
+            String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+            // Empty strings should still be included
+            assertTrue(lineProtocol.contains("empty_tag="));
+            assertTrue(lineProtocol.contains("empty_field=\"\""));
+        }
+
+        @Test
+        @DisplayName("Should maintain field order consistency")
+        void testFieldOrderConsistency() {
+            List<String> columnNames = Arrays.asList("z_field", "a_field", "m_field");
+            List<DataType> columnTypes =
+                    Arrays.asList(DataTypes.INT(), DataTypes.INT(), DataTypes.INT());
+
+            when(resolvedSchema.getColumnNames()).thenReturn(columnNames);
+            when(resolvedSchema.getColumnDataTypes()).thenReturn(columnTypes);
+
+            FieldMappingConfig fm = FieldMappingConfig.builder().build();
+            RowDataToLineProtocolConverter converter =
+                    new RowDataToLineProtocolConverter(resolvedSchema, fm, "test");
+
+            // Generate multiple line protocols to check consistency
+            for (int i = 0; i < 5; i++) {
+                GenericRowData row = GenericRowData.of(1, 2, 3);
+                row.setRowKind(RowKind.INSERT);
+
+                String lineProtocol = converter.convertToLineProtocol(row, "test");
+
+                // Fields should appear in a consistent order
+                int zPos = lineProtocol.indexOf("z_field");
+                int aPos = lineProtocol.indexOf("a_field");
+                int mPos = lineProtocol.indexOf("m_field");
+
+                assertTrue(zPos > 0);
+                assertTrue(aPos > 0);
+                assertTrue(mPos > 0);
+            }
+        }
+    }
+}

--- a/src/test/java/org/opengemini/flink/table/e2e/OpenGeminiTableE2ETest.java
+++ b/src/test/java/org/opengemini/flink/table/e2e/OpenGeminiTableE2ETest.java
@@ -348,7 +348,7 @@ public class OpenGeminiTableE2ETest {
                                 "  'field-fields' = 'metric1,metric2',"
                                 + // Specific fields
                                 "  'timestamp-field' = 'event_time',"
-                                + "  'write-precision' = 'ms',"
+                                + "  'source-precision' = 'ms',"
                                 + "  'ignore-null-values' = 'true'"
                                 + ")",
                         host, port, TEST_DATABASE);


### PR DESCRIPTION
Fixes #16 and #7 
**Description:**

### Summary
This PR introduces significant performance and architectural improvements to the Flink OpenGemini Connector by adding direct Line Protocol conversion support and decoupling the converter from configuration.

### Changes Made

#### Core Architecture Changes
- **Decoupled Converter**: Moved converter from `OpenGeminiSinkConfiguration` to be a separate parameter in `OpenGeminiSink` constructor
- **Dual Converter Support**: 
  - Added `OpenGeminiLineProtocolConverter<T>` interface for direct Line Protocol generation
  - Retained `OpenGeminiPointConverter<T>` for backward compatibility
- **Direct Conversion Path**: Eliminated intermediate Point object creation for Line Protocol conversion

#### New Components
- `SimpleOpenGeminiLineProtocolConverter`: Builder-pattern utility for creating Line Protocol converters
- `EnhancedOpenGeminiClient`: Extended client with `writeLineProtocol()` and `writeLineProtocols()` methods
- `OpenGeminiClientFactory`: Factory for creating enhanced client instances
- `AbstractRowDataConverter`: Base class for Table API converters

#### Table API Improvements
- Added `RowDataToLineProtocolConverter` for direct Table API to Line Protocol conversion
- Added `converter.type` configuration option (defaults to `line-protocol`)
- Fixed timestamp handling - BIGINT timestamps now correctly treated as milliseconds
-  Renamed `write-precision` to `source-precision` for clarity


### Performance Impact
- **Performance improvement** with Line Protocol converter
- **Reduced GC pressure** from fewer object allocations
- **Lower latency** due to eliminated conversion steps

### Testing
- Added `RowDataToLineProtocolConverterTest` with 22 test cases covering:
  - Basic Line Protocol generation
  - Special character escaping
  - Data type formatting
  - Null value handling
  - Timestamp conversion
- Added `ConverterTypeSelectionTest` for converter selection logic
- Updated existing tests for new constructor signatures

### Breaking Changes
- `OpenGeminiSink` constructor now requires converter as separate parameter
- `OpenGeminiSinkConfiguration` no longer contains converter

### Migration Guide
**Before:**
```java
OpenGeminiSinkConfiguration<MyData> config = OpenGeminiSinkConfiguration.<MyData>builder()
    .setConverter(new MyDataConverter())
    .build();
stream.addSink(new OpenGeminiSink<>(config));
```

**After:**
```java
OpenGeminiSinkConfiguration<MyData> config = OpenGeminiSinkConfiguration.<MyData>builder()
    .build();
OpenGeminiLineProtocolConverter<MyData> converter = new MyDataLineProtocolConverter();
stream.addSink(new OpenGeminiSink<>(config, converter));
```

### Checklist
- [x] Code compiles without warnings
- [x] All tests pass
- [x] Documentation updated
- [x] Performance benchmarks completed
- [x] Backward compatibility maintained (via Point converter)